### PR TITLE
Use '&amp;' rather than '&'

### DIFF
--- a/gameandwatch/theme.xml
+++ b/gameandwatch/theme.xml
@@ -124,7 +124,7 @@
 		</textlist>
 
 		<text name="System_Desc" extra="true">
-			<text>Game & Watch. 1980-1991. LCD game console.</text>
+			<text>Game &amp; Watch. 1980-1991. LCD game console.</text>
 			<forceUppercase>0</forceUppercase>
 			<size>0.200 0.204</size>
 			<pos>0.559 0.677</pos>


### PR DESCRIPTION
The '&' character is invalid in XML.

I noticed that when trying to get some info from the theme.xml files with the xmlstarlet tool. The tool failed to parse this file because of this invalid character. 

According to the [XML Specification](https://www.w3.org/TR/xml/#syntax): 
> The ampersand character (&) **MUST NOT** appear in their literal form, except when used as markup delimiters, or within a comment, a processing instruction, or a CDATA section. If they are needed elsewhere, they **MUST** be escaped using either numeric character references or the string `&amp;`