### PR TITLE
using "x" rather than " × "

### DIFF
--- a/mastersystem/theme.xml
+++ b/mastersystem/theme.xml
@@ -124,7 +124,7 @@
 		</textlist>
 
 		<text name="System_Desc" extra="true">
-			<text>Sega Master System. Released in 1985. 32 colors (of 64 total) at 256 × 192 pixels.</text>
+			<text>Sega Master System. Released in 1985. 32 colors (of 64 total) at 256x192 pixels.</text>
 			<forceUppercase>0</forceUppercase>
 			<size>0.200 0.204</size>
 			<pos>0.569 0.677</pos>


### PR DESCRIPTION
When using xmlstarlet tool it says that the "×" character isn't UTF-8. I checked the theme.xml for other systems (such as nes, megadrive, snes) and they use the "x" character (with no spaces before and after) when describing the resolution. The Master System's theme.xml is the only using " × ".

Comparison:
**NES:** Nintendo Entertainment System. 1985. 25 colors @ **256x240** pixels.
**SNES:** Super Nintendo Entertainment System. 1991. 256 colors at **256x224** pixels.
**Mega Drive:** Sega Mega Drive. Released in 1988. Displays 61 colors at **320x224** pixels.
**Master System:** Sega Master System. Released in 1985. 32 colors (of 64 total) at **256 × 192** pixels.