### PR TITLE
Fixed comment tags.

### DIFF
--- a/retropie/theme.xml
+++ b/retropie/theme.xml
@@ -116,13 +116,13 @@
 		</textlist>
 		
 
-		<!---<image name="Bottom Console Image" extra="true">
+		<!--<image name="Bottom Console Image" extra="true">
 			<tile>false</tile>
 			<pos>0.880 0.788</pos>
 			<origin>0.5 0.5</origin>
 			<maxSize>0.25 0.25</maxSize>
 			<path>./console.png</path>
-		</image>--->
+		</image>-->
 
 		<text name="System_Desc" extra="true">
 			<text></text>


### PR DESCRIPTION
As we can see the xmlstarlet tool takes the [XML Specification](https://www.w3.org/TR/xml/) very seriously. :-) It is complaining about the comments tags here.

According to the [comments section of XML Specification](https://www.w3.org/TR/xml/#sec-comments): "the grammar does not allow a comment ending in `--->`".