### PR TITLE
Missing Angle Bracket causing XML parse to fail.

### DIFF
--- a/psp/theme.xml
+++ b/psp/theme.xml
@@ -81,7 +81,7 @@
 			<origin>0.5 0.5</origin>
 		</image>
 		
-		<image name="background"
+		<image name="background">
 			<tile>false</tile>
 			<pos>0 0</pos>
 			<origin>0 0</origin>


### PR DESCRIPTION
Background was missing a closing ">" so I added it.